### PR TITLE
modified translation to work with selections as well as by the tab trigger

### DIFF
--- a/Snippets/d3r.html.translate.sublime-snippet
+++ b/Snippets/d3r.html.translate.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<?${TM_PHP_OPEN_TAG}=\$this->t("$1")?>$0
+<?${TM_PHP_OPEN_TAG}=\$this->t("$1$SELECTION")?>$0
 ]]></content>
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>t</tabTrigger>


### PR DESCRIPTION
Helps when converting existing text to use translate select the text then select the translate snippet in the command panel
