### PR TITLE
Added space between tags on translate snippet

### DIFF
--- a/Snippets/d3r.html.translate.sublime-snippet
+++ b/Snippets/d3r.html.translate.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<?${TM_PHP_OPEN_TAG}=\$this->t("$1$SELECTION")?>$0
+<?${TM_PHP_OPEN_TAG}= \$this->t("$1$SELECTION") ?>$0
 ]]></content>
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>t</tabTrigger>


### PR DESCRIPTION
Just because it looks nicer and I think we agreed to have spaces for readability
