### PR TITLE
Improve the dbname in all of the field snippets

### DIFF
--- a/Snippets/d3r.xml.field.asset.sublime-snippet
+++ b/Snippets/d3r.xml.field.asset.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>Asset</type>
     <required>False</required>
     <listing>False</listing>

--- a/Snippets/d3r.xml.field.calculated.sublime-snippet
+++ b/Snippets/d3r.xml.field.calculated.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>Calculated</type>
     <listing>True</listing>
     <method>getStock</method>

--- a/Snippets/d3r.xml.field.checkbox.sublime-snippet
+++ b/Snippets/d3r.xml.field.checkbox.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>Checkbox</type>
     <!-- <default>$3</default> -->
     <required>False</required>

--- a/Snippets/d3r.xml.field.date.sublime-snippet
+++ b/Snippets/d3r.xml.field.date.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>Date</type>
     <!-- <default>${3:now}</default> -->
     <required>False</required>

--- a/Snippets/d3r.xml.field.datetime.sublime-snippet
+++ b/Snippets/d3r.xml.field.datetime.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>DateTime</type>
     <!-- <default>${3:now}</default> -->
     <required>False</required>

--- a/Snippets/d3r.xml.field.dynamiclist.sublime-snippet
+++ b/Snippets/d3r.xml.field.dynamiclist.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>DynamicList</type>
     <!-- <default>$3</default> -->
     <!-- <suppress_blank>True</suppress_blank> -->

--- a/Snippets/d3r.xml.field.int.sublime-snippet
+++ b/Snippets/d3r.xml.field.int.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>Int</type>
     <!-- <default>$3</default> -->
     <required>False</required>

--- a/Snippets/d3r.xml.field.linkmodel.sublime-snippet
+++ b/Snippets/d3r.xml.field.linkmodel.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>LinkModel</type>
     <required>True</required>
     <model>$2</model>

--- a/Snippets/d3r.xml.field.linksimple.sublime-snippet
+++ b/Snippets/d3r.xml.field.linksimple.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>LinkSimple</type>
     <required>True</required>
     <model>$2</model>

--- a/Snippets/d3r.xml.field.linktomany.sublime-snippet
+++ b/Snippets/d3r.xml.field.linktomany.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>LinkToMany</type>
     <model>$2</model>
     <listing>False</listing>

--- a/Snippets/d3r.xml.field.multicurrency.sublime-snippet
+++ b/Snippets/d3r.xml.field.multicurrency.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>MultiCurrency</type>
     <!-- <default>$3</default> -->
     <hide_currency>True</hide_currency>

--- a/Snippets/d3r.xml.field.select.sublime-snippet
+++ b/Snippets/d3r.xml.field.select.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>Select</type>
     <options>
         <option value="$3">$4</option>

--- a/Snippets/d3r.xml.field.selectcallback.sublime-snippet
+++ b/Snippets/d3r.xml.field.selectcallback.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>SelectCallback</type>
     <callback>$2</callback>
     <!-- <default>$3</default> -->

--- a/Snippets/d3r.xml.field.selectmultiple.sublime-snippet
+++ b/Snippets/d3r.xml.field.selectmultiple.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>SelectMultiple</type>
     <options>
         <option value="$3">$4</option>

--- a/Snippets/d3r.xml.field.selectobject.sublime-snippet
+++ b/Snippets/d3r.xml.field.selectobject.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>SelectObject</type>
     <model>$2</model>
     <!-- <method>$3</method> -->

--- a/Snippets/d3r.xml.field.text.sublime-snippet
+++ b/Snippets/d3r.xml.field.text.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 <field>
     <name>$1</name>
-    <!-- <dbname>${1/[ ]/_/ig}</dbname> -->
+    <!-- <dbname>${1/^(\w)|( (\w))/(?1:\l\1:)(?2:_\l\3:)/g}</dbname> -->
     <type>Text</type>
     <!-- <default>$3</default> -->
     <required>False</required>


### PR DESCRIPTION
This brings an improvement to the regex in the fields to better format the dbname portion of the snippet by forcing lowercasing.

So before when you created a field using the snippet and gave it the name `My Custom Field`

The result would be `<dbname>My_Custom_Field</dbname>`

Now it should be `<dbname>my_custom_field</dbname>`
